### PR TITLE
RailsからmusicbrainzミラーサーバのAPIへ接続

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -67,3 +67,6 @@ gem "nokogiri"
 
 # css-framework
 gem "tailwindcss-rails", "~> 4.3"
+
+# HTTP Client
+gem "httparty"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -97,6 +97,7 @@ GEM
     concurrent-ruby (1.3.5)
     connection_pool (2.5.3)
     crass (1.0.6)
+    csv (3.3.5)
     date (3.4.1)
     debug (1.11.0)
       irb (~> 1.10)
@@ -118,6 +119,10 @@ GEM
       net-http (>= 0.5.0)
     globalid (1.2.1)
       activesupport (>= 6.1)
+    httparty (0.23.1)
+      csv
+      mini_mime (>= 1.0.0)
+      multi_xml (>= 0.5.2)
     i18n (1.14.7)
       concurrent-ruby (~> 1.0)
     io-console (0.8.1)
@@ -147,6 +152,8 @@ GEM
     mini_mime (1.1.5)
     minitest (5.25.5)
     msgpack (1.8.0)
+    multi_xml (0.7.2)
+      bigdecimal (~> 3.1)
     net-http (0.6.0)
       uri
     net-imap (0.5.9)
@@ -347,6 +354,7 @@ DEPENDENCIES
   capybara
   debug
   devise
+  httparty
   jbuilder
   jsbundling-rails
   nokogiri

--- a/app/services/music_brainz_service.rb
+++ b/app/services/music_brainz_service.rb
@@ -1,0 +1,8 @@
+class MusicBrainzService
+  # 環境変数対応でローカル/本番両対応
+  BASE_URL = ENV.fetch("MUSICBRAINZ_API_URL", "http://localhost:5000/ws/2")
+
+  def initialize
+    @client = HTTParty
+  end
+end


### PR DESCRIPTION
**概要**
gem httpartyをインストール
楽曲データの検索に用いるmusicbrainzミラーサーバのAPIエンドポイントを設定