### PR TITLE
楽曲検索機能 コントローラー/ビューの実装

### DIFF
--- a/app/controllers/songs_controller.rb
+++ b/app/controllers/songs_controller.rb
@@ -1,0 +1,248 @@
+class SongsController < ApplicationController
+  def index
+    if params[:title].present?
+      @songs = search_songs(params[:title], params[:artist])
+
+      if @songs.size == 1
+        redirect_to song_path(@songs.first.id)
+      end
+    else
+      @songs = []
+    end
+  end
+
+  def show
+    @song = find_song_by_id(params[:id])
+
+    if @song.nil?
+      redirect_to root_path, alert: "楽曲が見つかりませんでした"
+      return
+    end
+
+    # 作詞家・作曲家の他の作品を非同期取得（パフォーマンス改善）
+    @composer_works = {}
+    @lyricist_works = {}
+
+    # 作曲家・作詞家のIDを収集
+    composer_ids = @song.composers.select { |c| c.is_a?(Hash) && c[:mbid].present? }
+    lyricist_ids = @song.lyricists.select { |l| l.is_a?(Hash) && l[:mbid].present? }
+
+    # 並列処理でAPI呼び出しを高速化
+    threads = []
+
+    composer_ids.each do |composer|
+      threads << Thread.new do
+        # キャッシュを優先的にチェック
+        cache_key = "artist_works:#{composer[:mbid]}"
+        other_works = Rails.cache.read(cache_key)
+
+        if other_works.nil?
+          # キャッシュがない場合のみAPI呼び出し（初期表示用の20件のみ）
+          service = MusicBrainzService.new
+          works = service.find_artist_works_fast(composer[:mbid], 20)  # 初期表示分のみ取得
+          other_works = works.reject { |work| work.id == @song.id }
+
+          # 部分的なキャッシュを保存（完全版は「もっと見る」時に取得）
+          Rails.cache.write("#{cache_key}_partial", other_works, expires_in: 1.hour)
+        end
+
+        Thread.current[:result] = {
+          type: :composer,
+          name: composer[:name],
+          data: {
+            initial: other_works.take(10),
+            has_more: other_works.size > 10,
+            mbid: composer[:mbid]
+          }
+        }
+      end
+    end
+
+    lyricist_ids.each do |lyricist|
+      threads << Thread.new do
+        # キャッシュを優先的にチェック
+        cache_key = "artist_works:#{lyricist[:mbid]}"
+        other_works = Rails.cache.read(cache_key)
+
+        if other_works.nil?
+          # キャッシュがない場合のみAPI呼び出し（初期表示用の20件のみ）
+          service = MusicBrainzService.new
+          works = service.find_artist_works_fast(lyricist[:mbid], 20)  # 初期表示分のみ取得
+          other_works = works.reject { |work| work.id == @song.id }
+
+          # 部分的なキャッシュを保存（完全版は「もっと見る」時に取得）
+          Rails.cache.write("#{cache_key}_partial", other_works, expires_in: 1.hour)
+        end
+
+        Thread.current[:result] = {
+          type: :lyricist,
+          name: lyricist[:name],
+          data: {
+            initial: other_works.take(10),
+            has_more: other_works.size > 10,
+            mbid: lyricist[:mbid]
+          }
+        }
+      end
+    end
+
+    # 全スレッドの完了を待機
+    threads.each do |thread|
+      thread.join
+      result = thread[:result]
+      if result[:type] == :composer
+        @composer_works[result[:name]] = result[:data]
+      else
+        @lyricist_works[result[:name]] = result[:data]
+      end
+    end
+  end
+
+  def search
+    redirect_to songs_path(title: params[:title], artist: params[:artist])
+  end
+
+  # アーティスト情報の非同期読み込み（キャッシュ優先）
+  def load_artists
+    song_ids = params[:song_ids]&.split(",") || []
+
+    # まずキャッシュから取得を試行
+    cached_results = []
+    uncached_song_ids = []
+
+    song_ids.each do |song_id|
+      cached_artist = Rails.cache.read("song_artist:#{song_id}")
+      if cached_artist
+        cached_results << {
+          id: song_id,
+          artist: cached_artist
+        }
+      else
+        uncached_song_ids << song_id
+      end
+    end
+
+    # キャッシュにないもののみAPI取得
+    api_results = []
+    if uncached_song_ids.any?
+      # パフォーマンス最適化：少ない並列数で安定化
+      max_concurrent_threads = 3  # 大幅削減で安定性重視
+      service = MusicBrainzService.new
+
+      Rails.logger.info "Loading artists for #{uncached_song_ids.size} uncached songs"
+
+      # より小さなバッチで処理
+      uncached_song_ids.each_slice(max_concurrent_threads) do |batch|
+        Rails.logger.info "Processing batch: #{batch}"
+        start_time = Time.now
+
+        # 各バッチを並列処理
+        threads = batch.map do |song_id|
+          Thread.new do
+            begin
+              song = service.find_work_by_id(song_id)
+              artist_name = song&.artist || "情報なし"
+
+              # 取得結果をキャッシュ（1時間）
+              Rails.cache.write("song_artist:#{song_id}", artist_name, expires_in: 1.hour)
+
+              Thread.current[:result] = {
+                id: song_id,
+                artist: artist_name
+              }
+            rescue => e
+              Rails.logger.error "Error loading artist for #{song_id}: #{e.message}"
+              Thread.current[:result] = {
+                id: song_id,
+                artist: "情報なし"
+              }
+            end
+          end
+        end
+
+        # バッチの結果を収集（タイムアウト付き）
+        batch_results = threads.map do |thread|
+          # 最大5秒でタイムアウト
+          if thread.join(5)
+            thread[:result]
+          else
+            Rails.logger.warn "Thread timeout for artist loading"
+            thread.kill
+            nil
+          end
+        end.compact
+
+        api_results.concat(batch_results)
+
+        elapsed = Time.now - start_time
+        Rails.logger.info "Batch completed in #{elapsed.round(2)}s"
+
+        # バッチ間の待機（APIサーバー保護）
+        sleep(0.1) if uncached_song_ids.size > max_concurrent_threads
+      end
+    end
+
+    # キャッシュ結果とAPI結果をマージ
+    all_results = cached_results + api_results
+
+    render json: { artists: all_results }
+  end
+
+  def artist_works
+    artist_id = params[:artist_id]
+    artist_type = params[:artist_type]
+    current_song_id = params[:current_song_id]
+    offset = params[:offset]&.to_i || 10  # 既に表示している10件をスキップ
+
+    # キャッシュから作品を取得（なければAPI呼び出し）
+    other_works = Rails.cache.read("artist_works:#{artist_id}")
+
+    if other_works.nil?
+      # キャッシュにない場合のみAPI呼び出し
+      service = MusicBrainzService.new
+      all_works = service.find_artist_works_fast(artist_id, 100)
+      other_works = all_works.reject { |work| work.id == current_song_id }
+      # 新しいキャッシュを保存
+      Rails.cache.write("artist_works:#{artist_id}", other_works, expires_in: 1.hour)
+    else
+      # キャッシュされたデータから現在の楽曲を除外（念のため）
+      other_works = other_works.reject { |work| work.id == current_song_id }
+    end
+
+    # 10件ずつ表示（API負荷軽減）
+    limit = 10  # API負荷軽減とUX改善のため削減
+    works_to_show = other_works[offset, limit] || []
+    has_more = other_works.size > (offset + limit)
+
+    render json: {
+      works: works_to_show.map { |work| {
+        id: work.id,
+        title: work.title,
+        artist: work.artist,
+        creator_names: work.creator_names
+      } },
+      has_more: has_more
+    }
+  end
+
+  private
+
+  def search_songs(title, artist = nil)
+    # シンプルなAPI実装（高速かつ正確）
+    service = MusicBrainzService.new
+    service.search_works(title, artist)
+  end
+
+  def find_song_by_id(id)
+    # シンプルなAPI実装
+    service = MusicBrainzService.new
+    song = service.find_work_by_id(id)
+
+    # Work IDで見つからない場合、Recording IDとして試す
+    if song.nil?
+      song = service.find_recording_by_id(id)
+    end
+
+    song
+  end
+end

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,5 +1,61 @@
-<div>
-  <h1 class="text-4xl text-green-700 font-semibold underline">Hello,world</h1>
-  <p>Find me in app/views/home/index.html.erb</p>
+<div class="min-h-screen bg-gray-950">
+  <div class="container mx-auto px-4 py-16">
+    <div class="text-center mb-16">
+      <h1 class="text-5xl font-bold text-gray-100 mb-4">
+        誰が作った曲か<br>
+        <span class="bg-gradient-to-r from-green-400 to-blue-500 text-transparent bg-clip-text">発見しよう</span>
+      </h1>
+      <p class="text-xl text-gray-400 mt-6">
+        お気に入りの曲の作曲家・作詞家から楽曲を見つける
+      </p>
+    </div>
+    
+    <div class="max-w-2xl mx-auto">
+      <div class="bg-gray-900 rounded-2xl p-8 shadow-2xl border border-gray-800">
+        <%= form_with url: search_songs_path, method: :get, local: true, class: "space-y-4" do |f| %>
+          <div>
+            <%= f.label :title, "曲名を入力", class: "block text-gray-300 text-sm font-medium mb-2" %>
+            <%= f.text_field :title, placeholder: "例: Lemon", class: "w-full px-4 py-3 bg-gray-800 border border-gray-700 rounded-lg focus:outline-none focus:border-green-500 transition-colors text-gray-100 placeholder-gray-500", required: true %>
+          </div>
+          <div>
+            <%= f.label :artist, "アーティスト名（任意）", class: "block text-gray-300 text-sm font-medium mb-2" %>
+            <%= f.text_field :artist, placeholder: "例: 米津玄師", class: "w-full px-4 py-3 bg-gray-800 border border-gray-700 rounded-lg focus:outline-none focus:border-green-500 transition-colors text-gray-100 placeholder-gray-500" %>
+          </div>
+          <%= f.submit "検索する", class: "w-full bg-green-600 hover:bg-green-700 text-white font-bold py-4 rounded-lg transition-all duration-200 transform hover:scale-[1.02] cursor-pointer" %>
+        <% end %>
+      </div>
+    </div>
+    
+    <div class="grid grid-cols-1 md:grid-cols-3 gap-8 mt-16">
+      <div class="bg-gray-900 rounded-xl p-6 border border-gray-800">
+        <div class="text-green-500 mb-4">
+          <svg class="w-12 h-12" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"></path>
+          </svg>
+        </div>
+        <h3 class="text-xl font-semibold text-gray-100 mb-2">簡単検索</h3>
+        <p class="text-gray-400">作曲家・作詞家を発見、クリエイターの他の作品を試聴</p>
+      </div>
+      
+      <div class="bg-gray-900 rounded-xl p-6 border border-gray-800">
+        <div class="text-blue-500 mb-4">
+          <svg class="w-12 h-12" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z"></path>
+          </svg>
+        </div>
+        <h3 class="text-xl font-semibold text-gray-100 mb-2">お気に入り登録</h3>
+        <p class="text-gray-400">気に入った曲をお気に入りに保存（準備中）</p>
+      </div>
+      
+      <div class="bg-gray-900 rounded-xl p-6 border border-gray-800">
+        <div class="text-purple-500 mb-4">
+          <svg class="w-12 h-12" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19V6l12-3v13M9 19c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2zm12-3c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2zM9 10l12-3"></path>
+          </svg>
+        </div>
+        <h3 class="text-xl font-semibold text-gray-100 mb-2">プレイリスト作成</h3>
+        <p class="text-gray-400">同じクリエイターの曲でプレイリストを作成（準備中）</p>
+      </div>
+    </div>
+  </div>
 </div>
-<button class="btn btn-primary">Hello daisyUI!</button>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -4,7 +4,7 @@
       <%= link_to "Who Wrote The Song", root_path, class: "text-xl font-bold bg-gradient-to-r from-green-400 to-blue-500 text-transparent bg-clip-text hover:from-green-500 hover:to-blue-600 transition-all duration-300 mr-12" %>
       
       <div class="hidden lg:flex items-center gap-6">
-        <%= link_to "探す", "#", class: "text-gray-300 hover:text-white font-medium transition-colors duration-200" %>
+        <%= link_to "探す", root_path, class: "text-gray-300 hover:text-white font-medium transition-colors duration-200" %>
         <% if user_signed_in? %>
           <%= link_to "お気に入り(準備中)", "#", class: "text-gray-300 hover:text-white font-medium transition-colors duration-200" %>
           <%= link_to "プレイリスト(準備中)", "#", class: "text-gray-300 hover:text-white font-medium transition-colors duration-200" %>
@@ -31,7 +31,7 @@
           <li class="menu-title">
             <span class="text-gray-400"><%= current_user.display_name %></span>
           </li>
-          <li><%= link_to "探す", "#" %></li>
+          <li><%= link_to "探す", root_path %></li>
           <li><%= link_to "お気に入り(準備中)", "#" %></li>
           <li><%= link_to "プレイリスト(準備中)", "#" %></li>
           <li>
@@ -48,7 +48,7 @@
           </svg>
         </div>
         <ul tabindex="0" class="menu menu-sm dropdown-content mt-3 z-[1] p-2 shadow-lg bg-gray-800 text-gray-300 rounded-box w-52 right-0 border border-gray-700">
-          <li><%= link_to "探す", "#" %></li>
+          <li><%= link_to "探す", root_path %></li>
           <li><%= link_to "ログイン", new_user_session_path %></li>
           <li><%= link_to "アカウント登録", new_user_registration_path %></li>
         </ul>

--- a/app/views/songs/_work_item.html.erb
+++ b/app/views/songs/_work_item.html.erb
@@ -1,0 +1,16 @@
+<div class="bg-gray-800 rounded-lg p-4 work-item">
+  <h3 class="font-medium text-gray-100 mb-2"><%= work.title %></h3>
+  <p class="text-sm text-gray-400 mb-2" data-artist-info="<%= work.id %>">
+    アーティスト: <span class="text-gray-300 artist-name">
+      <%= work.artist.present? ? work.artist : "読み込み中..." %>
+    </span>
+    <% if work.loading_artist || work.artist.blank? %>
+      <span class="artist-loading text-gray-500 text-xs ml-1">🔄</span>
+    <% end %>
+  </p>
+  <% if work.creator_names.present? %>
+    <p class="text-sm text-gray-400">
+      <%= work.creator_names %>
+    </p>
+  <% end %>
+</div>

--- a/app/views/songs/index.html.erb
+++ b/app/views/songs/index.html.erb
@@ -1,0 +1,166 @@
+<div class="min-h-screen bg-gray-950 pt-8">
+  <div class="container mx-auto px-4">
+    <div class="mb-8">
+      <h1 class="text-3xl font-bold text-gray-100 mb-4">検索結果</h1>
+      
+      <% if params[:title].present? %>
+        <p class="text-gray-400">
+          「<span class="text-gray-200 font-medium"><%= params[:title] %></span>」
+          <% if params[:artist].present? %>
+            （アーティスト: <span class="text-gray-200 font-medium"><%= params[:artist] %></span>）
+          <% end %>
+          の検索結果
+        </p>
+      <% end %>
+    </div>
+
+    <% if @songs.present? %>
+      <div class="grid gap-4">
+        <% @songs.each do |song| %>
+          <div class="bg-gray-900 rounded-lg p-6 border border-gray-800 hover:border-gray-700 transition-colors">
+            <%= link_to song_path(song.id), class: "block" do %>
+              <div class="flex justify-between items-start">
+                <div>
+                  <h2 class="text-xl font-semibold text-gray-100 mb-2">
+                    <%= song.title %>
+                  </h2>
+                  <p class="text-gray-400 mb-2" data-artist-info="<%= song.id %>">
+                    アーティスト: <span class="text-gray-300 artist-name">
+                      <%= song.artist.present? ? song.artist : "読み込み中..." %>
+                    </span>
+                    <% if song.loading_artist || song.artist.blank? %>
+                      <span class="artist-loading text-gray-500 text-sm ml-2">🔄</span>
+                    <% end %>
+                  </p>
+                  <% if song.creator_names.present? %>
+                    <p class="text-sm text-gray-400 mt-2">
+                      <%= song.creator_names %>
+                    </p>
+                  <% else %>
+                    <p class="text-sm text-gray-500 mt-2">
+                      ※作詞作曲情報なし
+                    </p>
+                  <% end %>
+                </div>
+                <div class="text-green-500">
+                  <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path>
+                  </svg>
+                </div>
+              </div>
+            <% end %>
+          </div>
+        <% end %>
+        
+        <!-- 検索結果が上限に達している場合の誘導 -->
+        <% if @songs.present? && @songs.size >= 10 && params[:artist].blank? %>
+          <div class="bg-gray-800 rounded-lg p-6 mt-6 border border-gray-700">
+            <h3 class="text-lg font-medium text-gray-100 mb-3">🔍 お探しの楽曲が見つからない場合</h3>
+            <p class="text-gray-300 mb-4">
+              同じタイトルの楽曲が多数あるため、10件のみ表示しています。<br>
+              <span class="text-green-400">アーティスト名を追加</span>することで、お探しの楽曲を見つけやすくなります。
+            </p>
+            <form method="GET" action="<%= songs_path %>" class="flex gap-3">
+              <input type="hidden" name="title" value="<%= params[:title] %>">
+              <input type="text" name="artist" placeholder="例: YOASOBI、米津玄師、Official髭男dism" 
+                     class="flex-1 px-4 py-2 bg-gray-700 border border-gray-600 rounded-lg text-gray-100 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-green-500 focus:border-transparent">
+              <button type="submit" class="px-6 py-2 bg-green-600 text-white rounded-lg hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2 focus:ring-offset-gray-900 transition-colors">
+                絞り込み検索
+              </button>
+            </form>
+            <p class="text-xs text-gray-500 mt-2">
+              💡 部分的なアーティスト名でも検索できます（例: 「結束バンド」→「結束」）
+            </p>
+          </div>
+        <% end %>
+      </div>
+    <% else %>
+      <div class="bg-gray-900 rounded-lg p-8 text-center border border-gray-800">
+        <p class="text-gray-400 mb-4">
+          <% if params[:title].present? %>
+            該当する楽曲が見つかりませんでした。
+          <% else %>
+            検索条件を入力してください。
+          <% end %>
+        </p>
+        <%= link_to "検索画面に戻る", root_path, class: "text-green-500 hover:text-green-400 font-medium" %>
+      </div>
+    <% end %>
+  </div>
+</div>
+
+<script>
+  console.log('Script loaded in search results page');
+  
+  // アーティスト情報の非同期読み込み
+  function loadArtistsOnSearchPage() {
+    console.log('loadArtistsOnSearchPage called');
+    
+    // 少し待ってから実行（DOMの完全な構築を待つ）
+    setTimeout(function() {
+      const artistElements = document.querySelectorAll('[data-artist-info]');
+      console.log(`Found ${artistElements.length} artist elements`);
+      
+      const loadingArtists = Array.from(artistElements).filter(el => 
+        el.querySelector('.artist-loading')
+      );
+      console.log(`Found ${loadingArtists.length} elements with loading artists`);
+      
+      if (loadingArtists.length > 0) {
+        // 読み込み中のアーティスト情報のIDを収集
+        const songIds = loadingArtists.map(el => el.dataset.artistInfo);
+        console.log('Loading artists for IDs:', songIds);
+        
+        // 非同期でアーティスト情報を取得
+        fetch(`/songs/load_artists?song_ids=${songIds.join(',')}`, {
+        headers: {
+          'Accept': 'application/json',
+          'X-Requested-With': 'XMLHttpRequest',
+          'X-CSRF-Token': document.querySelector('meta[name="csrf-token"]').content
+        }
+      })
+      .then(response => response.json())
+      .then(data => {
+        // アーティスト情報を更新
+        data.artists.forEach(artist => {
+          const element = document.querySelector(`[data-artist-info="${artist.id}"]`);
+          if (element) {
+            const nameSpan = element.querySelector('.artist-name');
+            const loadingSpan = element.querySelector('.artist-loading');
+            
+            if (nameSpan) {
+              nameSpan.textContent = artist.artist;
+            }
+            if (loadingSpan) {
+              loadingSpan.remove();
+            }
+          }
+        });
+      })
+      .catch(error => {
+        console.error('アーティスト情報の読み込みに失敗しました:', error);
+        // エラー時は読み込み中アイコンを削除
+        loadingArtists.forEach(el => {
+          const loadingSpan = el.querySelector('.artist-loading');
+          if (loadingSpan) {
+            loadingSpan.remove();
+          }
+        });
+      });
+      }
+    }, 200); // 0.2秒待機に短縮
+  }
+  
+  // Turbo対応のイベントリスナー
+  document.addEventListener('DOMContentLoaded', loadArtistsOnSearchPage);
+  document.addEventListener('turbo:load', loadArtistsOnSearchPage);
+  document.addEventListener('turbo:render', loadArtistsOnSearchPage);
+  
+  // 既にDOMが読み込まれている場合は即座に実行
+  if (document.readyState === 'loading') {
+    console.log('Document is loading');
+  } else {
+    console.log('Document already loaded, executing immediately');
+    loadArtistsOnSearchPage();
+  }
+</script>

--- a/app/views/songs/show.html.erb
+++ b/app/views/songs/show.html.erb
@@ -1,0 +1,512 @@
+<div class="min-h-screen bg-gray-950 pt-8">
+  <div class="container mx-auto px-4 max-w-4xl">
+    <% if @song.present? %>
+      <!-- 楽曲基本情報 -->
+      <div class="bg-gray-900 rounded-lg p-6 mb-8 border border-gray-800">
+        <h1 class="text-3xl font-bold text-gray-100 mb-4">
+          <%= @song.title %>
+        </h1>
+        <% if @song.artist.present? %>
+          <p class="text-lg text-gray-300">
+            アーティスト: <span class="text-gray-100 font-medium"><%= @song.artist %></span>
+          </p>
+        <% end %>
+      </div>
+
+      <!-- クリエイター情報 -->
+      <% if @song.same_creator? %>
+        <!-- 作詞作曲が同じ人物 -->
+        <div class="bg-gray-900 rounded-lg p-6 border border-gray-800">
+          <% @song.composers.each do |composer| %>
+            <div class="mb-6">
+              <div class="flex items-center mb-4">
+                <h2 class="text-xl font-semibold text-gray-100 mr-3">作詞作曲:</h2>
+                <p class="text-lg text-gray-200 font-medium">
+                  <%= composer[:name] %>
+                </p>
+              </div>
+              
+              <div class="border-t border-gray-800 pt-4">
+                <h3 class="text-gray-400 mb-3">他の作品</h3>
+                <% composer_data = @composer_works[composer[:name]] %>
+                <% if composer_data && composer_data[:initial].any? %>
+                  <div class="max-h-64 overflow-y-auto space-y-3" id="composer-<%= composer[:name].parameterize %>-inline-works">
+                    <% composer_data[:initial].each do |work| %>
+                      <%= render 'work_item', work: work %>
+                    <% end %>
+                  </div>
+                  <% if composer_data[:has_more] %>
+                    <div class="mt-4 text-center">
+                      <%= button_tag "もっと見る", 
+                          type: "button",
+                          class: "text-green-500 hover:text-green-400 font-medium transition-colors duration-200 text-sm",
+                          data: { 
+                            artist_id: composer_data[:mbid],
+                            artist_name: composer[:name],
+                            artist_type: "composer",
+                            current_song_id: @song.id,
+                            target: "composer-#{composer[:name].parameterize}-inline-works"
+                          },
+                          onclick: "loadMoreWorks(this)" %>
+                    </div>
+                  <% end %>
+                <% else %>
+                  <div class="text-gray-500 text-center py-4">
+                    <p class="text-sm">他の作品が見つかりませんでした</p>
+                  </div>
+                <% end %>
+              </div>
+            </div>
+          <% end %>
+        </div>
+      <% else %>
+        <!-- 作曲家セクション -->
+        <% if @song.composers.present? %>
+          <div class="bg-gray-900 rounded-lg p-6 mb-6 border border-gray-800">
+            <% @song.composers.each do |composer| %>
+              <div class="mb-6 last:mb-0">
+                <div class="flex items-center mb-4">
+                  <h2 class="text-xl font-semibold text-gray-100 mr-3">作曲:</h2>
+                  <p class="text-lg text-gray-200 font-medium">
+                    <%= composer[:name] %>
+                  </p>
+                </div>
+                
+                <div class="border-t border-gray-800 pt-4">
+                  <h3 class="text-gray-400 mb-3">他の作品</h3>
+                  <% composer_data = @composer_works[composer[:name]] %>
+                  <% if composer_data && composer_data[:initial].any? %>
+                    <div class="max-h-64 overflow-y-auto space-y-3" id="composer-<%= composer[:name].parameterize %>-separate-works">
+                      <% composer_data[:initial].each do |work| %>
+                        <%= render 'work_item', work: work %>
+                      <% end %>
+                    </div>
+                    <% if composer_data[:has_more] %>
+                      <div class="mt-4 text-center">
+                        <%= button_tag "もっと見る", 
+                            type: "button",
+                            class: "text-green-500 hover:text-green-400 font-medium transition-colors duration-200 text-sm",
+                            data: { 
+                              artist_id: composer_data[:mbid],
+                              artist_name: composer[:name],
+                              artist_type: "composer",
+                              current_song_id: @song.id,
+                              target: "composer-#{composer[:name].parameterize}-separate-works"
+                            },
+                            onclick: "loadMoreWorks(this)" %>
+                      </div>
+                    <% end %>
+                  <% else %>
+                    <div class="text-gray-500 text-center py-4">
+                      <p class="text-sm">他の作品が見つかりませんでした</p>
+                    </div>
+                  <% end %>
+                </div>
+              </div>
+            <% end %>
+          </div>
+        <% end %>
+
+        <!-- 作詞家セクション -->
+        <% if @song.lyricists.present? %>
+          <div class="bg-gray-900 rounded-lg p-6 border border-gray-800">
+            <% @song.lyricists.each do |lyricist| %>
+              <div class="mb-6 last:mb-0">
+                <div class="flex items-center mb-4">
+                  <h2 class="text-xl font-semibold text-gray-100 mr-3">作詞:</h2>
+                  <p class="text-lg text-gray-200 font-medium">
+                    <%= lyricist[:name] %>
+                  </p>
+                </div>
+                
+                <div class="border-t border-gray-800 pt-4">
+                  <h3 class="text-gray-400 mb-3">他の作品</h3>
+                  <% lyricist_data = @lyricist_works[lyricist[:name]] %>
+                  <% if lyricist_data && lyricist_data[:initial].any? %>
+                    <div class="max-h-64 overflow-y-auto space-y-3" id="lyricist-<%= lyricist[:name].parameterize %>-separate-works">
+                      <% lyricist_data[:initial].each do |work| %>
+                        <%= render 'work_item', work: work %>
+                      <% end %>
+                    </div>
+                    <% if lyricist_data[:has_more] %>
+                      <div class="mt-4 text-center">
+                        <%= button_tag "もっと見る", 
+                            type: "button",
+                            class: "text-green-500 hover:text-green-400 font-medium transition-colors duration-200 text-sm",
+                            data: { 
+                              artist_id: lyricist_data[:mbid],
+                              artist_name: lyricist[:name],
+                              artist_type: "lyricist",
+                              current_song_id: @song.id,
+                              target: "lyricist-#{lyricist[:name].parameterize}-separate-works"
+                            },
+                            onclick: "loadMoreWorks(this)" %>
+                      </div>
+                    <% end %>
+                  <% else %>
+                    <div class="text-gray-500 text-center py-4">
+                      <p class="text-sm">他の作品が見つかりませんでした</p>
+                    </div>
+                  <% end %>
+                </div>
+              </div>
+            <% end %>
+          </div>
+        <% end %>
+      <% end %>
+
+      <!-- クリエイター情報なし -->
+      <% if @song.composers.blank? && @song.lyricists.blank? %>
+        <div class="bg-gray-900 rounded-lg p-8 text-center border border-gray-800">
+          <p class="text-gray-400 mb-4">
+            作曲家・作詞家の情報がまだ登録されていません。
+          </p>
+        </div>
+      <% end %>
+    <% end %>
+
+
+    <!-- 戻るボタン -->
+    <div class="mt-8 text-center">
+      <%= link_to "検索画面に戻る", root_path, class: "text-green-500 hover:text-green-400 font-medium" %>
+    </div>
+  </div>
+</div>
+
+<script>
+  console.log('Script loaded successfully');
+  
+  function loadInitialWorks(button) {
+    const artistId = button.dataset.artistId;
+    const artistName = button.dataset.artistName;
+    const artistType = button.dataset.artistType;
+    const currentSongId = button.dataset.currentSongId;
+    const targetId = button.dataset.target;
+    
+    // ローディング表示
+    button.innerHTML = '読み込み中...';
+    button.disabled = true;
+    button.classList.add('opacity-50');
+    
+    // Ajax リクエスト（最初の5件）
+    fetch(`/songs/artist_works?artist_id=${artistId}&artist_type=${artistType}&current_song_id=${currentSongId}&offset=0`, {
+      headers: {
+        'Accept': 'application/json',
+        'X-Requested-With': 'XMLHttpRequest',
+        'X-CSRF-Token': document.querySelector('meta[name="csrf-token"]').content
+      }
+    })
+    .then(response => response.json())
+    .then(data => {
+      const container = document.getElementById(targetId);
+      const initialButton = document.getElementById(`${targetId.replace('-works', '-initial')}`);
+      const moreButtonContainer = document.getElementById(`${targetId.replace('-works', '-more-button')}`);
+      
+      // 初期の5件を表示
+      const worksToShow = data.works.slice(0, 5);
+      worksToShow.forEach(work => {
+        const workDiv = createWorkElement(work);
+        container.appendChild(workDiv);
+      });
+      
+      // コンテナを表示
+      container.classList.remove('hidden');
+      // 初期ボタンを非表示
+      initialButton.style.display = 'none';
+      
+      // 5件以上ある場合は「もっと見る」ボタンを表示
+      if (data.works.length > 5) {
+        moreButtonContainer.classList.remove('hidden');
+      }
+    })
+    .catch(error => {
+      console.error('Error loading initial works:', error);
+      button.innerHTML = 'もっと見る';
+      button.disabled = false;
+      button.classList.remove('opacity-50');
+      alert('作品の読み込みに失敗しました。');
+    });
+  }
+
+  // loadAllWorksは削除（もっと見るに統一）
+
+  function loadMoreWorks(button) {
+    const artistId = button.dataset.artistId;
+    const artistName = button.dataset.artistName;
+    const artistType = button.dataset.artistType;
+    const currentSongId = button.dataset.currentSongId;
+    const targetId = button.dataset.target;
+    
+    // 既に表示されている作品数を取得
+    const existingWorks = document.querySelectorAll(`#${targetId} .work-item`).length;
+    
+    // ローディング表示の改善
+    const loadingSpan = document.getElementById(`${targetId}-loading`);
+    if (loadingSpan) {
+      loadingSpan.classList.remove('hidden');
+    }
+    button.innerHTML = '読み込み中... <span class="animate-pulse">⏳</span>';
+    button.disabled = true;
+    button.classList.add('opacity-70');
+    
+    // Ajax リクエスト
+    fetch(`/songs/artist_works?artist_id=${artistId}&artist_type=${artistType}&current_song_id=${currentSongId}&offset=${existingWorks}`, {
+      headers: {
+        'Accept': 'application/json',
+        'X-Requested-With': 'XMLHttpRequest',
+        'X-CSRF-Token': document.querySelector('meta[name="csrf-token"]').content
+      }
+    })
+    .then(response => response.json())
+    .then(data => {
+      const container = document.getElementById(targetId);
+      
+      // 新しい作品を追加（10件分）
+      const fragment = document.createDocumentFragment();
+      data.works.forEach(work => {
+        const workDiv = createWorkElement(work);
+        fragment.appendChild(workDiv);
+      });
+      container.appendChild(fragment);
+      
+      // 新しく追加された要素のアーティスト情報を段階的に読み込み
+      const newElements = container.querySelectorAll('.work-item .artist-loading');
+      if (newElements.length > 0) {
+        const songIds = Array.from(newElements).map(el => 
+          el.closest('[data-artist-info]').dataset.artistInfo
+        );
+        // 段階的読み込みでUX改善
+        loadArtistsProgressively(songIds);
+      }
+      
+      // ローディング非表示
+      if (loadingSpan) {
+        loadingSpan.classList.add('hidden');
+      }
+      
+      // 全て表示したらボタンを非表示
+      if (!data.has_more) {
+        // ボタンの親要素（divコンテナ）を削除
+        const buttonContainer = button.parentElement;
+        if (buttonContainer) {
+          buttonContainer.remove();
+        }
+      } else {
+        button.innerHTML = 'もっと見る';
+        button.disabled = false;
+        button.classList.remove('opacity-70');
+      }
+    })
+    .catch(error => {
+      console.error('Error loading more works:', error);
+      if (loadingSpan) {
+        loadingSpan.classList.add('hidden');
+      }
+      button.innerHTML = 'もっと見る';
+      button.disabled = false;
+      button.classList.remove('opacity-70');
+      alert('作品の読み込みに失敗しました。');
+    });
+  }
+  
+  function createWorkElement(work) {
+    const div = document.createElement('div');
+    div.className = 'bg-gray-800 rounded-lg p-4 work-item';
+    
+    let content = `<h3 class="font-medium text-gray-100 mb-2">${escapeHtml(work.title)}</h3>`;
+    
+    // アーティスト情報（非同期読み込み対応）
+    content += `<p class="text-sm text-gray-400 mb-2" data-artist-info="${work.id}">
+      アーティスト: <span class="text-gray-300 artist-name">${work.artist || '取得中...'}</span>
+      ${(!work.artist || work.artist === '') ? '<span class="artist-loading text-gray-500 text-xs ml-1 animate-pulse">⏳</span>' : ''}
+    </p>`;
+    
+    if (work.creator_names) {
+      content += `<p class="text-sm text-gray-400">${escapeHtml(work.creator_names)}</p>`;
+    }
+    
+    div.innerHTML = content;
+    
+    // アーティスト情報の遅延読み込みは、全てのDOM追加後に一括実行するため、ここでは実行しない
+    
+    return div;
+  }
+
+  // アーティスト情報を段階的に読み込む関数（UX最適化版）
+  function loadArtistsProgressively(songIds) {
+    if (songIds.length === 0) return;
+    
+    // より小さなバッチサイズでスムーズな表示
+    const batchSize = 8; // バッチサイズを削減してより頻繁に更新
+    
+    // 最初のバッチを即座に処理
+    const firstBatch = songIds.slice(0, batchSize);
+    if (firstBatch.length > 0) {
+      loadArtistsForElements(firstBatch);
+    }
+    
+    // 残りがある場合はより短い間隔で処理
+    const remainingSongIds = songIds.slice(batchSize);
+    if (remainingSongIds.length > 0) {
+      setTimeout(() => {
+        loadArtistsProgressively(remainingSongIds);
+      }, 100); // 0.1秒待機でより滑らかな表示
+    }
+  }
+  
+  // 複数要素のアーティスト情報を一括で読み込む関数
+  function loadArtistsForElements(songIds) {
+    if (songIds.length === 0) return;
+    
+    fetch(`/songs/load_artists?song_ids=${songIds.join(',')}`, {
+      headers: {
+        'Accept': 'application/json',
+        'X-Requested-With': 'XMLHttpRequest',
+        'X-CSRF-Token': document.querySelector('meta[name="csrf-token"]').content
+      }
+    })
+    .then(response => response.json())
+    .then(data => {
+      data.artists.forEach(artist => {
+        const elements = document.querySelectorAll(`[data-artist-info="${artist.id}"]`);
+        elements.forEach(element => {
+          const nameSpan = element.querySelector('.artist-name');
+          const loadingSpan = element.querySelector('.artist-loading');
+          
+          if (nameSpan) {
+            nameSpan.textContent = artist.artist;
+            // 取得完了の視覚的フィードバック
+            nameSpan.classList.add('text-green-300');
+            setTimeout(() => {
+              nameSpan.classList.remove('text-green-300');
+              nameSpan.classList.add('text-gray-300');
+            }, 1000);
+          }
+          if (loadingSpan) {
+            loadingSpan.remove();
+          }
+        });
+      });
+    })
+    .catch(error => {
+      console.error('アーティスト情報の読み込みに失敗しました:', error);
+    });
+  }
+  
+  // 単一要素のアーティスト情報を読み込む関数（下位互換のため残す）
+  function loadArtistForElement(songId) {
+    loadArtistsForElements([songId]);
+  }
+  
+  function escapeHtml(text) {
+    const div = document.createElement('div');
+    div.textContent = text;
+    return div.innerHTML;
+  }
+
+  // アーティスト情報の非同期読み込み（work_item用）
+  // 重複実行防止のためのフラグ
+  let artistLoadingInProgress = false;
+  
+  // Turbo対応のイベントリスナー
+  function loadArtistsOnPageLoad() {
+    console.log('loadArtistsOnPageLoad called');
+    
+    // 既に読み込み中の場合は実行しない
+    if (artistLoadingInProgress) {
+      console.log('Artist loading already in progress, skipping...');
+      return;
+    }
+    
+    // 少し待ってから実行（DOMの完全な構築を待つ）
+    setTimeout(function() {
+      // 再度チェック（setTimeout後に他の処理が開始されている可能性）
+      if (artistLoadingInProgress) {
+        console.log('Artist loading started by another process, skipping...');
+        return;
+      }
+      
+      console.log('Starting artist loading process...');
+      artistLoadingInProgress = true;
+      
+      const artistElements = document.querySelectorAll('[data-artist-info]');
+      console.log(`Found ${artistElements.length} total elements with data-artist-info`);
+      
+      const loadingArtists = Array.from(artistElements).filter(el => 
+        el.querySelector('.artist-loading')
+      );
+      
+      console.log(`Found ${loadingArtists.length} elements with loading artists`);
+      
+      if (loadingArtists.length > 0) {
+        // 読み込み中のアーティスト情報のIDを収集
+        const songIds = loadingArtists.map(el => el.dataset.artistInfo);
+        console.log('Loading artists for song IDs:', songIds);
+        
+        // 非同期でアーティスト情報を取得
+        fetch(`/songs/load_artists?song_ids=${songIds.join(',')}`, {
+        headers: {
+          'Accept': 'application/json',
+          'X-Requested-With': 'XMLHttpRequest',
+          'X-CSRF-Token': document.querySelector('meta[name="csrf-token"]').content
+        }
+      })
+      .then(response => response.json())
+      .then(data => {
+        console.log('Received artist data:', data);
+        // アーティスト情報を更新
+        data.artists.forEach(artist => {
+          const elements = document.querySelectorAll(`[data-artist-info="${artist.id}"]`);
+          console.log(`Updating ${elements.length} elements for song ${artist.id}`);
+          elements.forEach(element => {
+            const nameSpan = element.querySelector('.artist-name');
+            const loadingSpan = element.querySelector('.artist-loading');
+            
+            if (nameSpan) {
+              nameSpan.textContent = artist.artist;
+            }
+            if (loadingSpan) {
+              loadingSpan.remove();
+            }
+          });
+        });
+        // 処理完了後にフラグをリセット
+        artistLoadingInProgress = false;
+      })
+      .catch(error => {
+        console.error('アーティスト情報の読み込みに失敗しました:', error);
+        // エラー時は読み込み中アイコンを削除
+        loadingArtists.forEach(el => {
+          const loadingSpan = el.querySelector('.artist-loading');
+          if (loadingSpan) {
+            loadingSpan.remove();
+          }
+        });
+        // エラー時もフラグをリセット
+        artistLoadingInProgress = false;
+      });
+      } else {
+        // 読み込み対象がない場合もフラグをリセット
+        artistLoadingInProgress = false;
+      }
+    }, 300); // 0.3秒待機に短縮してからアーティスト情報を読み込み
+  }
+
+  // ページ遷移時にフラグをリセット
+  document.addEventListener('turbo:before-visit', function() {
+    artistLoadingInProgress = false;
+  });
+  
+  // 複数のイベントに対応（Turbo対応）
+  document.addEventListener('DOMContentLoaded', loadArtistsOnPageLoad);
+  document.addEventListener('turbo:load', loadArtistsOnPageLoad);
+  document.addEventListener('turbo:render', loadArtistsOnPageLoad);
+  
+  // 即座に実行も試す（既にDOMが読み込まれている場合）
+  if (document.readyState === 'loading') {
+    console.log('Document is loading');
+  } else {
+    console.log('Document already loaded, executing immediately');
+    loadArtistsOnPageLoad();
+  }
+</script>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,4 +12,13 @@ Rails.application.routes.draw do
 
   # Defines the root path route ("/")
   root "home#index"
+
+  # Song search routes
+  resources :songs, only: [ :index, :show ] do
+    collection do
+      get :search
+      get :artist_works
+      get :load_artists  # アーティスト情報の非同期読み込み用
+    end
+  end
 end


### PR DESCRIPTION
**概要**
楽曲検索時の検索結果、詳細画面(作曲家/作詞家のその他作品を表示)するためのroute、controller、viewを作成

**詳細**
- ホーム画面へアプリ説明、検索フォーム追加
- route追加
- controller追加
- view追加